### PR TITLE
Features/specify OIDC claims as headers

### DIFF
--- a/Demo/SwizlyPeasy.Demo.API/Controllers/DemoController.cs
+++ b/Demo/SwizlyPeasy.Demo.API/Controllers/DemoController.cs
@@ -25,6 +25,18 @@ public class DemoController : ControllerBase
             .ToArray();
     }
 
+    [HttpGet("weather-anonymous")]
+    public IEnumerable<WeatherForecast> GetAnonymous()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+    }
+
     [Authorize("AreYouBob")]
     [HttpGet("weather-with-authorization")]
     public IEnumerable<WeatherForecast> GetWithAuthorization()

--- a/Demo/SwizlyPeasy.Demo.API/Extensions/AuthorizationExtensions.cs
+++ b/Demo/SwizlyPeasy.Demo.API/Extensions/AuthorizationExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System.Net;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using SwizlyPeasy.Demo.API.Authorization;
 
 namespace SwizlyPeasy.Demo.API.Extensions;
@@ -9,29 +6,16 @@ namespace SwizlyPeasy.Demo.API.Extensions;
 public static class AuthorizationExtensions
 {
     /// <summary>
-    ///     Adding demo authorization policy, checking if user's uid/sub matches bob's one
+    ///     Test policy, checking if user is bob
     /// </summary>
     /// <param name="services"></param>
-    public static void SetAuthenticationAndAuthorization(this IServiceCollection services)
+    public static void SetAuthorization(this IServiceCollection services)
     {
-        services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-            .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
-            {
-                options.Events.OnRedirectToAccessDenied = UnAuthorizedResponse;
-                options.Events.OnRedirectToLogin = UnAuthorizedResponse;
-            });
-
         services.AddAuthorization(options =>
         {
             options.AddPolicy("AreYouBob", policy =>
                 policy.Requirements.Add(new BobRequirement()));
         });
         services.AddSingleton<IAuthorizationHandler, AppAuthorizationHandler>();
-    }
-
-    private static Task UnAuthorizedResponse(RedirectContext<CookieAuthenticationOptions> context)
-    {
-        context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-        return Task.CompletedTask;
     }
 }

--- a/Demo/SwizlyPeasy.Demo.API/Program.cs
+++ b/Demo/SwizlyPeasy.Demo.API/Program.cs
@@ -1,3 +1,4 @@
+using SwizlyPeasy.Common.Auth;
 using SwizlyPeasy.Common.Extensions;
 using SwizlyPeasy.Common.HealthChecks;
 using SwizlyPeasy.Common.Middlewares;
@@ -15,7 +16,8 @@ builder.Services.AddSwaggerGen();
 
 // swizly peasy consul & health checks
 builder.Services.RegisterServiceToSwizlyPeasyGateway(builder.Configuration);
-builder.Services.SetAuthenticationAndAuthorization();
+builder.Services.SetSwizlyPeasyAuthentication();
+builder.Services.SetAuthorization();
 
 var app = builder.Build();
 app.UseSwizlyPeasyExceptions();
@@ -35,7 +37,6 @@ app.UseSwizlyPeasyHealthChecks();
 // mapping the headers as claims
 app.UseMiddleware<HeaderToClaimsMiddleware>();
 //---------------------------------------------
-
 app.UseAuthorization();
 app.MapControllers();
 

--- a/Demo/SwizlyPeasy.Demo.API/appsettings.Development.json
+++ b/Demo/SwizlyPeasy.Demo.API/appsettings.Development.json
@@ -17,5 +17,18 @@
     "ServiceId": "1",
     "ServiceAddress": "http://demo",
     "HealthCheckPath": "health"
+  },
+  "ClaimsConfig": {
+    "ClaimsHeaderPrefix": "SWIZLY-PEASY",
+    "ClaimsAsHeaders": [
+      "sub",
+      "email",
+      "name",
+      "family_name"
+    ],
+    "JwtToIdentityClaimsMappings": {
+      "sub": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+      "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+    }
   }
 }

--- a/SwizlyPeasy.Common/Auth/ClientAuthExtensions.cs
+++ b/SwizlyPeasy.Common/Auth/ClientAuthExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SwizlyPeasy.Common.Auth;
+
+public static class ClientAuthExtensions
+{
+    /// <summary>
+    ///     Setting "dummy" authentication
+    /// </summary>
+    /// <param name="services"></param>
+    public static void SetSwizlyPeasyAuthentication(this IServiceCollection services)
+    {
+        services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+            .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
+            {
+                options.Events.OnRedirectToAccessDenied = UnAuthorizedResponse;
+                options.Events.OnRedirectToLogin = UnAuthorizedResponse;
+            });
+    }
+
+    private static Task UnAuthorizedResponse(RedirectContext<CookieAuthenticationOptions> context)
+    {
+        context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+        return Task.CompletedTask;
+    }
+}

--- a/SwizlyPeasy.Common/Auth/OpenIdConnectExtensions.cs
+++ b/SwizlyPeasy.Common/Auth/OpenIdConnectExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Security.Claims;
+using IdentityModel;
 using IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -178,12 +179,6 @@ public static class OpenIdConnectExtensions
             var scopes = config.Scopes;
             foreach (var scope in scopes) options.Scope.Add(scope);
 
-            //Mapping claims for later usage, accessing them over context.User
-            options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "sub");
-            options.ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
-            options.ClaimActions.MapJsonKey("sub", "sub");
-            options.ClaimActions.MapJsonKey("email", "email");
-
             options.GetClaimsFromUserInfoEndpoint = true;
 
             //fix for production environment
@@ -196,7 +191,6 @@ public static class OpenIdConnectExtensions
             };
 
             //options.Events.OnMessageReceived
-
             options.BackchannelHttpHandler = new HttpClientHandler { UseCookies = false };
         });
 

--- a/SwizlyPeasy.Common/Constants.cs
+++ b/SwizlyPeasy.Common/Constants.cs
@@ -12,5 +12,8 @@ public static class Constants
     public const string OidcConfigSection = "OidcConfig";
     public const string ServiceDiscoveryConfigSection = "ServiceDiscovery";
     public const string ServiceRegistrationConfigSection = "ServiceRegistration";
+    public const string ClaimsConfigSection = "ClaimsConfig";
     public const string OidcPolicy = "oidc";
+    public const string SubClaim = "sub";
+    public const string EmailClaim = "email";
 }

--- a/SwizlyPeasy.Common/Dtos/ClaimsConfig.cs
+++ b/SwizlyPeasy.Common/Dtos/ClaimsConfig.cs
@@ -1,0 +1,22 @@
+﻿using System.Security.Claims;
+using IdentityModel;
+
+namespace SwizlyPeasy.Common.Dtos;
+
+public class ClaimsConfig
+{
+    public string ClaimsHeaderPrefix { get; set; } = "SWIZLY-PEASY";
+    public string[] ClaimsAsHeaders { get; set; } =
+    {
+        JwtClaimTypes.Subject,
+        JwtClaimTypes.Email,
+        JwtClaimTypes.Name,
+        JwtClaimTypes.FamilyName
+    };
+
+    public Dictionary<string, string> JwtToIdentityClaimsMappings { get; set; } = new()
+    {
+        { JwtClaimTypes.Subject, ClaimTypes.NameIdentifier },
+        { JwtClaimTypes.Email, ClaimTypes.Email }
+    };
+}

--- a/SwizlyPeasy.Common/Dtos/ClaimsConfig.cs
+++ b/SwizlyPeasy.Common/Dtos/ClaimsConfig.cs
@@ -1,22 +1,8 @@
-﻿using System.Security.Claims;
-using IdentityModel;
-
-namespace SwizlyPeasy.Common.Dtos;
+﻿namespace SwizlyPeasy.Common.Dtos;
 
 public class ClaimsConfig
 {
     public string ClaimsHeaderPrefix { get; set; } = "SWIZLY-PEASY";
-    public string[] ClaimsAsHeaders { get; set; } =
-    {
-        JwtClaimTypes.Subject,
-        JwtClaimTypes.Email,
-        JwtClaimTypes.Name,
-        JwtClaimTypes.FamilyName
-    };
-
-    public Dictionary<string, string> JwtToIdentityClaimsMappings { get; set; } = new()
-    {
-        { JwtClaimTypes.Subject, ClaimTypes.NameIdentifier },
-        { JwtClaimTypes.Email, ClaimTypes.Email }
-    };
+    public string[] ClaimsAsHeaders { get; set; } = Array.Empty<string>();
+    public Dictionary<string, string> JwtToIdentityClaimsMappings { get; set; } = new();
 }

--- a/SwizlyPeasy.Common/SwizlyPeasy.Common.csproj
+++ b/SwizlyPeasy.Common/SwizlyPeasy.Common.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>SwizlyPeasy.Common</PackageId>
-		<Version>0.0.3</Version>
+		<Version>0.0.4-alpha</Version>
 		<Authors>Guillaume Gnaegi</Authors>
 		<PackageDescription>This package contains the common classes (Exceptions) and Extension methods (health checks and OIDC configuration) for SwizlyPeasy.Gateway.</PackageDescription>
 		<RepositoryUrl>https://github.com/ggnaegi/SwizlyPeasy.Gateway</RepositoryUrl>

--- a/SwizlyPeasy.Consul/README.md
+++ b/SwizlyPeasy.Consul/README.md
@@ -32,5 +32,5 @@ The parameters in Service Discovery part are irrelevant for a client API, except
 
 - ServiceName: The service type name (the services will be grouped by service name)
 - ServiceId: The service id (for load balancing) -> Key is then "DemoAPI-1"
-- ServiceAddress: The started service address
+- ServiceAddress: The current service address
 - HealthCheckPath: The health endpoint path (you could use the health extension methods in SwizlyPeasy.Common)

--- a/SwizlyPeasy.Consul/SwizlyPeasy.Consul.csproj
+++ b/SwizlyPeasy.Consul/SwizlyPeasy.Consul.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>SwizlyPeasy.Consul</PackageId>
-		<Version>0.0.3</Version>
+		<Version>0.0.4-alpha</Version>
 		<Authors>Guillaume Gnaegi</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageDescription>This package contains the extension methods for service registration to consul and other consul services (agents, health, kv)</PackageDescription>

--- a/SwizlyPeasy.Gateway.API/appsettings.Development.json
+++ b/SwizlyPeasy.Gateway.API/appsettings.Development.json
@@ -21,5 +21,18 @@
     "LoadBalancingPolicy": "Random",
     "KeyValueStoreKey": "SwizlyPeasy.Gateway",
     "ServiceDiscoveryAddress": "http://consul:8500"
+  },
+  "ClaimsConfig": {
+    "ClaimsHeaderPrefix": "SWIZLY-PEASY",
+    "ClaimsAsHeaders": [
+      "sub",
+      "email",
+      "name",
+      "family_name"
+    ],
+    "JwtToIdentityClaimsMappings": {
+      "sub": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+      "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+    }
   }
 }

--- a/SwizlyPeasy.Gateway.API/routes.config.json
+++ b/SwizlyPeasy.Gateway.API/routes.config.json
@@ -25,6 +25,18 @@
           "Set": "de-CH"
         }
       ]
+    },
+    "route3": {
+      "ClusterId": "DemoAPI",
+      "Match": {
+        "Path": "/api/v1/demo/weather-anonymous"
+      },
+      "Transforms": [
+        {
+          "RequestHeader": "Accept-Language",
+          "Set": "de-CH"
+        }
+      ]
     }
   }
 }

--- a/SwizlyPeasy.Gateway.sln
+++ b/SwizlyPeasy.Gateway.sln
@@ -23,6 +23,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SwizlyPeasy.Gateway.API", "
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{E6726E42-D12B-4340-8301-7987F98C2FA4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8579360D-ABAD-4303-AAEC-45898B29C5E5}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+		README.md = README.md
+		sonar-project.properties = sonar-project.properties
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/SwizlyPeasy.Gateway/SwizlyPeasy.Gateway.csproj
+++ b/SwizlyPeasy.Gateway/SwizlyPeasy.Gateway.csproj
@@ -7,7 +7,7 @@
 		<UserSecretsId>fc61b5e3-488e-4be2-a3ea-236cd64c6123</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<PackageId>SwizlyPeasy.Gateway</PackageId>
-		<Version>0.0.3</Version>
+		<Version>0.0.4-alpha</Version>
 		<Authors>Guillaume Gnaegi</Authors>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageDescription>This package contains the extensions methods to configure and use the SwizlyPeasy.Gateway, a YARP-based gateway with OIDC authentication and Consul service discovery.</PackageDescription>


### PR DESCRIPTION
It should be possible to specify the claims that will be forwarded as headers. Also, some oidc claims should be mapped as identity claims and finally an header prefix should be defined.

Changes:
Adding ClaimsConfig Dto, with properties:
- ClaimsHeaderPrefix, the header prefix
- ClaimsAsHeaders, claims as headers
- JwtToIdentityClaimsMappings, oidc claims types mapped to identity claims types

```
"ClaimsConfig": {
    "ClaimsHeaderPrefix": "SWIZLY-PEASY",
    "ClaimsAsHeaders": [
      "sub",
      "email",
      "name",
      "family_name"
    ],
    "JwtToIdentityClaimsMappings": {
      "sub": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
      "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
    }
  }
```