### PR TITLE
Adding rate limiter configuration. 

### DIFF
--- a/Demo/SwizlyPeasy.Demo.API/Program.cs
+++ b/Demo/SwizlyPeasy.Demo.API/Program.cs
@@ -1,7 +1,6 @@
 using SwizlyPeasy.Common.Auth;
 using SwizlyPeasy.Common.Extensions;
 using SwizlyPeasy.Common.HealthChecks;
-using SwizlyPeasy.Common.Middlewares;
 using SwizlyPeasy.Consul.ServiceRegistration;
 using SwizlyPeasy.Demo.API.Extensions;
 
@@ -42,10 +41,9 @@ app.Run();
 namespace SwizlyPeasy.Demo.API
 {
     /// <summary>
-    /// For Integration Tests...
+    ///     For Integration Tests...
     /// </summary>
     public partial class Program
     {
-
     }
 }

--- a/SwizlyPeasy.Common/Constants.cs
+++ b/SwizlyPeasy.Common/Constants.cs
@@ -14,6 +14,7 @@ public static class Constants
     public const string ServiceDiscoveryConfigSection = "ServiceDiscovery";
     public const string ServiceRegistrationConfigSection = "ServiceRegistration";
     public const string ClaimsConfigSection = "ClaimsConfig";
+    public const string RateLimiterPoliciesSection = "RateLimiterPolicies";
     public const string OidcPolicy = "oidc";
     public const string SubClaim = "sub";
     public const string EmailClaim = "email";

--- a/SwizlyPeasy.Common/Dtos/RateLimiterPolicyConfig.cs
+++ b/SwizlyPeasy.Common/Dtos/RateLimiterPolicyConfig.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.RateLimiting;
+
+namespace SwizlyPeasy.Common.Dtos;
+
+public class RateLimiterPolicyConfig
+{
+    public string PolicyName { get; set; } = "DefaultPolicy";
+    public string RateLimiterType { get; set; } = nameof(FixedWindowRateLimiter);
+    public int PermitLimit { get; set; } = 100;
+    public int Window { get; set; } = 10;
+    public int ReplenishmentPeriod { get; set; } = 2;
+    public int QueueLimit { get; set; } = 2;
+    public int QueueProcessingOrder { get; set; } = 0;
+    public int SegmentsPerWindow { get; set; } = 8;
+    public int TokenLimit { get; set; } = 10;
+    public int TokensPerPeriod { get; set; } = 4;
+    public bool AutoReplenishment { get; set; } = false;
+}

--- a/SwizlyPeasy.Common/Exceptions/Rfc7807.cs
+++ b/SwizlyPeasy.Common/Exceptions/Rfc7807.cs
@@ -56,6 +56,11 @@ public static class Rfc7807
                 currentException.Status = 403;
                 currentException.Type = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403";
                 break;
+            case TooManyRequestsException:
+                currentException.Title = "Too Many Requests Exception";
+                currentException.Status = 429;
+                currentException.Type = "https://developer.mozilla.org/fr/docs/Web/HTTP/Status/429";
+                break;
         }
 
         return currentException;

--- a/SwizlyPeasy.Common/Exceptions/TooManyRequestsException.cs
+++ b/SwizlyPeasy.Common/Exceptions/TooManyRequestsException.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+
+namespace SwizlyPeasy.Common.Exceptions;
+
+[Serializable]
+public class TooManyRequestsException : DomainException
+{
+    /// <summary>
+    ///     Too Many Requests Exception, exception with status 429
+    /// </summary>
+    /// <param name="msg"></param>
+    /// <param name="innerException"></param>
+    public TooManyRequestsException(string? msg, Exception? innerException) : base(msg, innerException)
+    {
+    }
+
+    /// <summary>
+    ///     For serialization purposes
+    /// </summary>
+    /// <param name="info"></param>
+    /// <param name="context"></param>
+    public TooManyRequestsException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/SwizlyPeasy.Common/Exceptions/TooManyRequestsException.cs
+++ b/SwizlyPeasy.Common/Exceptions/TooManyRequestsException.cs
@@ -19,7 +19,7 @@ public class TooManyRequestsException : DomainException
     /// </summary>
     /// <param name="info"></param>
     /// <param name="context"></param>
-    public TooManyRequestsException(SerializationInfo info, StreamingContext context) : base(info, context)
+    protected TooManyRequestsException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
         // ...
     }

--- a/SwizlyPeasy.Common/Exceptions/TooManyRequestsException.cs
+++ b/SwizlyPeasy.Common/Exceptions/TooManyRequestsException.cs
@@ -21,5 +21,6 @@ public class TooManyRequestsException : DomainException
     /// <param name="context"></param>
     public TooManyRequestsException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
+        // ...
     }
 }

--- a/SwizlyPeasy.Common/Extensions/RateLimiterExtensions.cs
+++ b/SwizlyPeasy.Common/Extensions/RateLimiterExtensions.cs
@@ -57,7 +57,7 @@ public static class RateLimiterExtensions
                     opt.SegmentsPerWindow = config.SegmentsPerWindow;
                 });
                 return;
-            case nameof(ConcurrencyLimiterOptions):
+            case nameof(ConcurrencyLimiter):
                 options.AddConcurrencyLimiter(config.PolicyName, opt =>
                 {
                     opt.PermitLimit = config.PermitLimit;

--- a/SwizlyPeasy.Common/Extensions/RateLimiterExtensions.cs
+++ b/SwizlyPeasy.Common/Extensions/RateLimiterExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SwizlyPeasy.Common.Dtos;
+using SwizlyPeasy.Common.Exceptions;
+
+namespace SwizlyPeasy.Common.Extensions;
+
+public static class RateLimiterExtensions
+{
+    public static void AddSwizlyPeasyRateLimiters(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = 429;
+            options.OnRejected = (context, _) =>
+            {
+                if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+                    throw new TooManyRequestsException(
+                        $"Too many requests. Please try again after {retryAfter.TotalMinutes} minute(s). ", null);
+
+                throw new TooManyRequestsException("Too many requests. Please try again later.", null);
+            };
+
+            var rateLimiterPolicyConfigs = new List<RateLimiterPolicyConfig>();
+            configuration.GetSection(Constants.RateLimiterPoliciesSection).Bind(rateLimiterPolicyConfigs);
+
+            foreach (var policyConfig in rateLimiterPolicyConfigs) options.AddSwizlyPeasyPolicy(policyConfig);
+        });
+    }
+
+    private static void AddSwizlyPeasyPolicy(this RateLimiterOptions options, RateLimiterPolicyConfig config)
+    {
+        switch (config.RateLimiterType)
+        {
+            case nameof(FixedWindowRateLimiter):
+                options.AddFixedWindowLimiter(config.PolicyName, opt =>
+                {
+                    opt.AutoReplenishment = config.AutoReplenishment;
+                    opt.PermitLimit = config.PermitLimit;
+                    opt.QueueLimit = config.QueueLimit;
+                    opt.QueueProcessingOrder = (QueueProcessingOrder)config.QueueProcessingOrder;
+                    opt.Window = TimeSpan.FromSeconds(config.Window);
+                });
+                return;
+            case nameof(SlidingWindowRateLimiter):
+                options.AddSlidingWindowLimiter(config.PolicyName, opt =>
+                {
+                    opt.AutoReplenishment = config.AutoReplenishment;
+                    opt.PermitLimit = config.PermitLimit;
+                    opt.QueueProcessingOrder = (QueueProcessingOrder)config.QueueProcessingOrder;
+                    opt.QueueLimit = config.QueueLimit;
+                    opt.Window = TimeSpan.FromSeconds(config.Window);
+                    opt.SegmentsPerWindow = config.SegmentsPerWindow;
+                });
+                return;
+            case nameof(ConcurrencyLimiterOptions):
+                options.AddConcurrencyLimiter(config.PolicyName, opt =>
+                {
+                    opt.PermitLimit = config.PermitLimit;
+                    opt.QueueLimit = config.QueueLimit;
+                    opt.QueueProcessingOrder = (QueueProcessingOrder)config.QueueProcessingOrder;
+                });
+                return;
+            case nameof(TokenBucketRateLimiter):
+                options.AddTokenBucketLimiter(config.PolicyName, opt =>
+                {
+                    opt.AutoReplenishment = config.AutoReplenishment;
+                    opt.QueueLimit = config.QueueLimit;
+                    opt.QueueProcessingOrder = (QueueProcessingOrder)config.QueueProcessingOrder;
+                    opt.ReplenishmentPeriod = TimeSpan.FromSeconds(config.ReplenishmentPeriod);
+                    opt.TokenLimit = config.TokenLimit;
+                    opt.TokensPerPeriod = config.TokensPerPeriod;
+                });
+                return;
+            default:
+                throw new InternalDomainException(
+                    $"The rate limiter type {config.RateLimiterType} is unknown, please check the app settings.",
+                    null);
+        }
+    }
+}

--- a/SwizlyPeasy.Common/SwizlyPeasy.Common.csproj
+++ b/SwizlyPeasy.Common/SwizlyPeasy.Common.csproj
@@ -17,6 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.9" />
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />

--- a/SwizlyPeasy.Common/SwizlyPeasy.Common.csproj
+++ b/SwizlyPeasy.Common/SwizlyPeasy.Common.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>SwizlyPeasy.Common</PackageId>
-		<Version>0.0.6-alpha</Version>
+		<Version>0.0.7-alpha</Version>
 		<Authors>Guillaume Gnaegi</Authors>
 		<PackageDescription>This package contains the common classes (Exceptions) and Extension methods (health checks and OIDC configuration) for SwizlyPeasy.Gateway.</PackageDescription>
 		<RepositoryUrl>https://github.com/ggnaegi/SwizlyPeasy.Gateway</RepositoryUrl>

--- a/SwizlyPeasy.Consul/SwizlyPeasy.Consul.csproj
+++ b/SwizlyPeasy.Consul/SwizlyPeasy.Consul.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>SwizlyPeasy.Consul</PackageId>
-		<Version>0.0.6-alpha</Version>
+		<Version>0.0.7-alpha</Version>
 		<Authors>Guillaume Gnaegi</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageDescription>This package contains the extension methods for service registration to consul and other consul services (agents, health, kv)</PackageDescription>

--- a/SwizlyPeasy.Gateway.API/Program.cs
+++ b/SwizlyPeasy.Gateway.API/Program.cs
@@ -27,9 +27,9 @@ finally
 namespace SwizlyPeasy.Gateway.API
 {
     /// <summary>
-    /// For Integration Tests...
+    ///     For Integration Tests...
     /// </summary>
-    public partial class Program
+    public class Program
     {
     }
 }

--- a/SwizlyPeasy.Gateway.API/appsettings.Development.json
+++ b/SwizlyPeasy.Gateway.API/appsettings.Development.json
@@ -38,5 +38,16 @@
       "sub": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
       "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
     }
-  }
+  },
+  "RateLimiterPolicies": [
+    {
+      "PolicyName": "swizly1",
+      "RateLimiterType": "FixedWindowRateLimiter",
+      "AutoReplenishment": true,
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "Window": 12
+    }
+  ]
 }

--- a/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest.json
+++ b/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest.json
@@ -39,5 +39,16 @@
       "sub": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
       "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
     }
-  }
+  },
+  "RateLimiterPolicies": [
+    {
+      "PolicyName": "swizly1",
+      "RateLimiterType": "FixedWindowRateLimiter",
+      "AutoReplenishment": true,
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "Window": 12
+    }
+  ]
 }

--- a/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest.json
+++ b/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest.json
@@ -49,6 +49,33 @@
       "QueueLimit": 0,
       "QueueProcessingOrder": 1,
       "Window": 12
+    },
+    {
+      "PolicyName": "swizly2",
+      "RateLimiterType": "SlidingWindowRateLimiter",
+      "AutoReplenishment": true,
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "Window": 12,
+      "SegmentsPerWindow": 3
+    },
+    {
+      "PolicyName": "swizly3",
+      "RateLimiterType": "ConcurrencyLimiter",
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1
+    },
+    {
+      "PolicyName": "swizly4",
+      "RateLimiterType": "TokenBucketRateLimiter",
+      "AutoReplenishment": true,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "ReplenishmentPeriod": 60,
+      "TokenLimit": 20,
+      "TokensPerPeriod": 10
     }
   ]
 }

--- a/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest2.json
+++ b/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest2.json
@@ -39,5 +39,16 @@
       "sub": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
       "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
     }
-  }
+  },
+  "RateLimiterPolicies": [
+    {
+      "PolicyName": "swizly1",
+      "RateLimiterType": "FixedWindowRateLimiter",
+      "AutoReplenishment": true,
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "Window": 12
+    }
+  ]
 }

--- a/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest2.json
+++ b/SwizlyPeasy.Gateway.API/appsettings.IntegrationTest2.json
@@ -49,6 +49,33 @@
       "QueueLimit": 0,
       "QueueProcessingOrder": 1,
       "Window": 12
+    },
+    {
+      "PolicyName": "swizly2",
+      "RateLimiterType": "SlidingWindowRateLimiter",
+      "AutoReplenishment": true,
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "Window": 12,
+      "SegmentsPerWindow": 3
+    },
+    {
+      "PolicyName": "swizly3",
+      "RateLimiterType": "ConcurrencyLimiter",
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1
+    },
+    {
+      "PolicyName": "swizly4",
+      "RateLimiterType": "TokenBucketRateLimiter",
+      "AutoReplenishment": true,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "ReplenishmentPeriod": 60,
+      "TokenLimit": 20,
+      "TokensPerPeriod": 10
     }
   ]
 }

--- a/SwizlyPeasy.Gateway.API/routes.config.json
+++ b/SwizlyPeasy.Gateway.API/routes.config.json
@@ -28,6 +28,7 @@
     },
     "route3": {
       "ClusterId": "DemoAPI",
+      "RateLimiterPolicy": "swizly1",
       "Match": {
         "Path": "/api/v1/demo/weather-anonymous"
       },

--- a/SwizlyPeasy.Gateway/Extensions/SetupServices.cs
+++ b/SwizlyPeasy.Gateway/Extensions/SetupServices.cs
@@ -36,6 +36,7 @@ public static class SetupServices
     {
         services.AddHttpContextAccessor();
         services.AddHttpClient();
+        services.AddSwizlyPeasyRateLimiters(configuration);
         services.AddControllers(options =>
         {
             options.ReturnHttpNotAcceptable = true;
@@ -68,6 +69,7 @@ public static class SetupServices
         app.UseMiddleware<ExceptionsHandlerMiddleware>();
         app.Use404AsException();
         app.UseRouting();
+        app.UseRateLimiter();
         app.UseSwizlyPeasyOidc();
         app.UseAuthentication();
         app.UseAuthorization();

--- a/SwizlyPeasy.Gateway/README.md
+++ b/SwizlyPeasy.Gateway/README.md
@@ -79,6 +79,10 @@ The syntax is the same as YARP configuration for routes.
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "AuthRedirectionConfig": {
+    "MainUrl": "/",
+    "IdpLogoutUrl": "https://demo.duendesoftware.com/Account/Logout/LoggedOut"
+  },
   "OidcConfig": {
     "RefreshThresholdMinutes": 1,
     "Origins": [],
@@ -87,14 +91,66 @@ The syntax is the same as YARP configuration for routes.
     "ClientId": "interactive.confidential.short",
     "ClientSecret": "secret",
     "RedirectUri": "",
-    "Scopes": [ "openid", "profile", "email", "offline_access" ]
+    "Scopes": [ "openid", "profile", "email", "offline_access" ],
+    "DisableOidc": true
   },
   "ServiceDiscovery": {
     "Scheme": "http",
-    "RefreshIntervalInSeconds": 120,
+    "RefreshIntervalInSeconds": 20,
     "LoadBalancingPolicy": "Random",
     "KeyValueStoreKey": "SwizlyPeasy.Gateway",
-    "ServiceDiscoveryAddress": "http://consul:8500"
-  }
+    "ServiceDiscoveryAddress": "http://localhost:8500"
+  },
+  "ClaimsConfig": {
+    "ClaimsHeaderPrefix": "SWIZLY-PEASY",
+    "ClaimsAsHeaders": [
+      "sub",
+      "email",
+      "name",
+      "family_name"
+    ],
+    "JwtToIdentityClaimsMappings": {
+      "sub": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+      "email": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+    }
+  },
+  "RateLimiterPolicies": [
+    {
+      "PolicyName": "swizly1",
+      "RateLimiterType": "FixedWindowRateLimiter",
+      "AutoReplenishment": true,
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "Window": 12
+    },
+    {
+      "PolicyName": "swizly2",
+      "RateLimiterType": "SlidingWindowRateLimiter",
+      "AutoReplenishment": true,
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "Window": 12,
+      "SegmentsPerWindow": 3
+    },
+    {
+      "PolicyName": "swizly3",
+      "RateLimiterType": "ConcurrencyLimiter",
+      "PermitLimit": 5,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1
+    },
+    {
+      "PolicyName": "swizly4",
+      "RateLimiterType": "TokenBucketRateLimiter",
+      "AutoReplenishment": true,
+      "QueueLimit": 0,
+      "QueueProcessingOrder": 1,
+      "ReplenishmentPeriod": 60,
+      "TokenLimit": 20,
+      "TokensPerPeriod": 10
+    }
+  ]
 }
 ```

--- a/SwizlyPeasy.Gateway/Services/RoutesConfigService.cs
+++ b/SwizlyPeasy.Gateway/Services/RoutesConfigService.cs
@@ -42,9 +42,7 @@ public class RoutesConfigService : IRoutesConfigService
             MaxRequestBodySize = section.ReadInt64(nameof(RouteConfig.MaxRequestBodySize)),
             ClusterId = section[nameof(RouteConfig.ClusterId)],
             AuthorizationPolicy = section[nameof(RouteConfig.AuthorizationPolicy)],
-#if NET7_0_OR_GREATER
             RateLimiterPolicy = section[nameof(RouteConfig.RateLimiterPolicy)],
-#endif
             CorsPolicy = section[nameof(RouteConfig.CorsPolicy)],
             Metadata = section.GetSection(nameof(RouteConfig.Metadata)).ReadStringDictionary(),
             Transforms = CreateTransforms(section.GetSection(nameof(RouteConfig.Transforms))),

--- a/SwizlyPeasy.Gateway/SwizlyPeasy.Gateway.csproj
+++ b/SwizlyPeasy.Gateway/SwizlyPeasy.Gateway.csproj
@@ -7,7 +7,7 @@
 		<UserSecretsId>fc61b5e3-488e-4be2-a3ea-236cd64c6123</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<PackageId>SwizlyPeasy.Gateway</PackageId>
-		<Version>0.0.6-alpha</Version>
+		<Version>0.0.7-alpha</Version>
 		<Authors>Guillaume Gnaegi</Authors>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageDescription>This package contains the extensions methods to configure and use the SwizlyPeasy.Gateway, a YARP-based gateway with OIDC authentication and Consul service discovery.</PackageDescription>

--- a/Test/SwizlyPeasy.Test.UnitTest/Exceptions/ExceptionTestData.cs
+++ b/Test/SwizlyPeasy.Test.UnitTest/Exceptions/ExceptionTestData.cs
@@ -14,6 +14,7 @@ public class ExceptionTestData : IEnumerable<object[]>
         yield return new object[] { new NotFoundDomainException("test", null), 404 };
         yield return new object[] { new UnAuthorizedDomainException("test", null), 401 };
         yield return new object[] { new UnprocessableEntityDomainException("test", null), 422 };
+        yield return new object[] { new TooManyRequestsException("test", null), 429 };
     }
 
     IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
Supporting simple policies (fixed window, sliding window, token bucket etc...). The policies can be configured in API gateway appsettings. Fixes #4 